### PR TITLE
Added path to find version 3.2. on Debian wheezy

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -71,8 +71,8 @@ endfunction ()
 find_path (PETSC_DIR include/petsc.h
   HINTS ENV PETSC_DIR
   PATHS
-  /usr/lib/petscdir/3.1 /usr/lib/petscdir/3.0.0 /usr/lib/petscdir/2.3.3 /usr/lib/petscdir/2.3.2 # Debian
-  $ENV{HOME}/petsc
+  /usr/lib/petscdir/3.1 /usr/lib/petscdir/3.2 /usr/lib/petscdir/3.0.0 /usr/lib/petscdir/2.3.3 /usr/lib/petscdir/2.3.2 # Debian
+  $ENV{HOME}/petsc /usr/include/petsc
   DOC "PETSc Directory")
 
 find_program (MAKE_EXECUTABLE NAMES make gmake)


### PR DESCRIPTION
With these small changes PETSc version 3.2 is found on Debian wheezy, the development version of Debian. This might be of interest to other people, too.