### PR TITLE
Add additional paths for Ubuntu 14.04/Debian testing and MacPorts

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -72,9 +72,11 @@ find_path (PETSC_DIR include/petsc.h
   HINTS ENV PETSC_DIR
   PATHS
   # Debian paths
-  /usr/lib/petscdir/3.4
+  /usr/lib/petscdir/3.4.2 /usr/lib/petscdir/3.4
   /usr/lib/petscdir/3.3 /usr/lib/petscdir/3.2 /usr/lib/petscdir/3.1
   /usr/lib/petscdir/3.0.0 /usr/lib/petscdir/2.3.3 /usr/lib/petscdir/2.3.2
+  # MacPorts path
+  /opt/local/lib/petsc
   $ENV{HOME}/petsc
   DOC "PETSc Directory")
 


### PR DESCRIPTION
This PR adds two default search paths to `FindPETSc.cmake`:
1. An additional directory for 3.4.2, since Debian testing and Ubuntu 14.04 now use this.
2. The path to the distribution provided by MacPorts.

I am hoping item 1 should be fairly unobtrusive. In terms of item 2, we are adding PETSc as an external dependency in another project in which OS X is a relatively common development environment, and this saves some effort in configuration. I thought I would add this into the PR in case you want to include it.
