### PR TITLE
Update FindPETSc.cmake to account for new directory structure

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -112,7 +112,10 @@ find_package_multipass (PETSc petsc_config_current
 
 # Determine whether the PETSc layout is old-style (through 2.3.3) or
 # new-style (>= 3.0.0)
-if (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc-conf/petscvariables") # > 3.5
+if (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables") # > 3.5.4
+  set (petsc_conf_rules "${PETSC_DIR}/lib/petsc/conf/rules")
+  set (petsc_conf_variables "${PETSC_DIR}/lib/petsc/conf/variables")
+elseif (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc-conf/petscvariables") # > 3.5
   set (petsc_conf_rules "${PETSC_DIR}/lib/petsc-conf/rules")
   set (petsc_conf_variables "${PETSC_DIR}/lib/petsc-conf/variables")
 elseif (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h")   # > 2.3.3


### PR DESCRIPTION
Directory structure changed as B.Smith pointed out in [petsc-users] For users of PETSc repository only on 04/12/2015
<<

   If you use PETSc 3.5.3 or earlier releases you can ignore this message. It only affects those using the pre-release PETSc repository code.

   I have changed some of the directory structure of PETSc which will your makefiles and Fortran source code. 

   The locations of the PETSc include makefiles has changed from  lib/petsc-conf/  to lib/petsc/conf  This means items such as 

include ${PETSC_DIR}/lib/petsc-conf/variables
include ${PETSC_DIR}/lib/petsc-conf/rules

   need to be changed in your makefiles to 

include ${PETSC_DIR}/lib/petsc/conf/variables
include ${PETSC_DIR}/lib/petsc/conf/rules


   The locations of the PETSc fortran include files has changed from petsc-finclude to petsc/finclude This means items such as

#include <petsc-finclude/petscsys.h>
#include <petsc-finclude/petscvec.h>

   in your Fortran source needs to be changed to 

#include <petsc/finclude/petscsys.h>
#include <petsc/finclude/petscvec.h>


  The reason for the change is to match Linux packaging standards for locations of files and directories. I hope this will be the last change for this for a long while, thanks for your patience

  Barry
>>