### PR TITLE
Fix PETSc 3.6 directory layout in FindPETSc.cmake.

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -112,9 +112,9 @@ find_package_multipass (PETSc petsc_config_current
 
 # Determine whether the PETSc layout is old-style (through 2.3.3) or
 # new-style (>= 3.0.0)
-if (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc-conf/petscvariables") # > 3.5
-  set (petsc_conf_rules "${PETSC_DIR}/lib/petsc-conf/rules")
-  set (petsc_conf_variables "${PETSC_DIR}/lib/petsc-conf/variables")
+if (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/lib/petsc/conf/petscvariables") # > 3.5
+  set (petsc_conf_rules "${PETSC_DIR}/lib/petsc/conf/rules")
+  set (petsc_conf_variables "${PETSC_DIR}/lib/petsc/conf/variables")
 elseif (EXISTS "${PETSC_DIR}/${PETSC_ARCH}/include/petscconf.h")   # > 2.3.3
   set (petsc_conf_rules "${PETSC_DIR}/conf/rules")
   set (petsc_conf_variables "${PETSC_DIR}/conf/variables")


### PR DESCRIPTION
PETSc 3.6 seems to use `petsc/conf` instead of `petsc-conf`.