### PR TITLE
resolve_libraries: Don't unset variables, set to "" instead

### DIFF
--- a/ResolveCompilerPaths.cmake
+++ b/ResolveCompilerPaths.cmake
@@ -42,8 +42,8 @@ include (CorrectWindowsPaths)
 
 macro (RESOLVE_LIBRARIES LIBS LINK_LINE)
   string (REGEX MATCHALL "((-L|-l|-Wl)([^\" ]+|\"[^\"]+\")|[^\" ]+\\.(a|so|dll|lib))" _all_tokens "${LINK_LINE}")
-  set (_libs_found)
-  set (_directory_list)
+  set (_libs_found "")
+  set (_directory_list "")
   foreach (token ${_all_tokens})
     if (token MATCHES "-L([^\" ]+|\"[^\"]+\")")
       # If it's a library path, add it to the list
@@ -58,7 +58,7 @@ macro (RESOLVE_LIBRARIES LIBS LINK_LINE)
       else (WIN32)
         string (REGEX REPLACE "^-l" "" token ${token})
       endif (WIN32)
-      set (_root)
+      set (_root "")
       if (token MATCHES "^/")	# We have an absolute path
         #separate into a path and a library name:
         string (REGEX MATCH "[^/]*\\.(a|so|dll|lib)$" libname ${token})


### PR DESCRIPTION
If nothing is appended to _libs_found, list(REMOVE_DUPLICATES ..) fails.
Apply change to all other variables in this file which are set to nothing.

Similar to _incs_found in 58a5c1628eb800268eadd77904ad3fb56b6f5641