### PR TITLE
Fix paths for Ubuntu 16.04+ and Debian 9

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -72,6 +72,7 @@ find_path (PETSC_DIR include/petsc.h
   HINTS ENV PETSC_DIR
   PATHS
   # Debian paths
+  /usr/lib/petsc
   /usr/lib/petscdir/3.5.1 /usr/lib/petscdir/3.5
   /usr/lib/petscdir/3.4.2 /usr/lib/petscdir/3.4
   /usr/lib/petscdir/3.3 /usr/lib/petscdir/3.2 /usr/lib/petscdir/3.1
@@ -224,6 +225,13 @@ show :
   else ()
     set (PETSC_LIBRARY_VEC "NOTFOUND" CACHE INTERNAL "Cleared" FORCE) # There is no libpetscvec
     petsc_find_library (SINGLE petsc)
+    # Debian 9/Ubuntu 16.04 uses _real and _complex extensions when using libraries in /usr/lib/petsc.
+    if (NOT PETSC_LIBRARY_SINGLE)
+      petsc_find_library (SINGLE petsc_real)
+    endif()
+    if (NOT PETSC_LIBRARY_SINGLE)
+      petsc_find_library (SINGLE petsc_complex)
+    endif()
     foreach (pkg SYS VEC MAT DM KSP SNES TS ALL)
       set (PETSC_LIBRARIES_${pkg} "${PETSC_LIBRARY_SINGLE}")
     endforeach ()


### PR DESCRIPTION
This is another approach that I've adopted to fix issue #16, but different in style to pull request #17 so might serve as an alternative choice. Gotta say these packages are a bit of a pain to use from a CMake perspective, but this is the least intrusive solution I could come up with.

The issue is that newer Ubuntu and Debian packages construct libraries that install into locations of the form: `/usr/lib/petscdir/VERSION/ARCH/lib/libpetsc_ARCH.so`. Following the usual Debian guidelines, these (and header includes) are then symlinked into places such as `/usr/lib/libpetsc.so` and friends, depending on the real/complex architecture choice selected in `update-alternatives`. This means that defining `PETSC_DIR` and `PETSC_ARCH` no longer works on these distributions, since the CMake configuration cannot find the `libpetsc_ARCH.so` library. 

The solution I have used here is to instead direct CMake to look inside `/usr/lib/petsc` first, which in these newer distributions is a symlink to the `petscdir/VERSION/ARCH` that has been selected by the user in `update-alternatives`. This has the advantage of no longer needing to look in hard-coded version-specific locations or hack around with `PETSC_ARCH`, and from the command line the library is detected automatically without manually specifying paths. However, the disadvantage is that we now need to additionally look for `libpetsc_real.so` and `libpetsc_complex.so`. Right now no other distributions use these alternative names, as far as I know, but I guess this could potentially be a cause for concern longer-term.