### PR TITLE
Add more general search path for PETSc

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -81,6 +81,7 @@ find_path (PETSC_DIR include/petsc.h
   HINTS ENV PETSC_DIR
   PATHS
   # Debian paths
+  /usr/lib/petsc/
   /usr/lib/petscdir/3.5.1 /usr/lib/petscdir/3.5
   /usr/lib/petscdir/3.4.2 /usr/lib/petscdir/3.4
   /usr/lib/petscdir/3.3 /usr/lib/petscdir/3.2 /usr/lib/petscdir/3.1


### PR DESCRIPTION
Hit this while trying to build a program on HPC and a local workstation.  Looks like some distros use a more general directory layout just sticking it in /usr/lib/petsc.