### PR TITLE
Issue #36: Changed an 'echo' to 'printf' for portability and robustness.

### DIFF
--- a/FindPETSc.cmake
+++ b/FindPETSc.cmake
@@ -156,7 +156,7 @@ if (petsc_conf_rules AND petsc_conf_variables AND NOT petsc_config_current)
 include ${petsc_conf_rules}
 include ${petsc_conf_variables}
 show :
-\t-@echo -n \${\${VARIABLE}}
+\t-@printf '%s' \${\${VARIABLE}}
 ")
 
   macro (PETSC_GET_VARIABLE name var)


### PR DESCRIPTION
Fix bug related to '^' character in PETSC_ARCH caused by non-portable 'echo'